### PR TITLE
Added more classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,12 +33,14 @@ setup(
     ],
     classifiers=[
         'Environment :: Console',
+        'Intended Audience :: End Users/Desktop',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Topic :: Games/Entertainment :: Puzzle Games',
     ],
     entry_points={
         'console_scripts':[


### PR DESCRIPTION
This commit adds a classifier for Topic so it shows up in https://pypi.python.org/pypi?:action=browse&show=all&c=312 (where I expected to find it). It also adds a classifier for the type of users (which can be anyone, so end users on the desktop, albeit in a terminal window).
